### PR TITLE
Added Request Headers in GetInvoice.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -37,33 +37,33 @@ type Invoice struct {
 	Token                 string
 	Price                 float64
 	Currency              string
-	OrderId               string
-	ItemDesc              string
-	ItemCode              string
-	NotificationEmail     string
-	NotificationUrl       string
-	RedirectUrl           string
-	PosData               string
-	TransactionSpeed      string
-	FullNotifications     string
-	ExtendedNotifications string
-	Physical              string
-	Buyer                 Buyer
-	PaymentCurrencies     []string
-	JsonPayProRequired    string
+	OrderId               string   `json:",omitempty"`
+	ItemDesc              string   `json:",omitempty"`
+	ItemCode              string   `json:",omitempty"`
+	NotificationEmail     string   `json:",omitempty"`
+	NotificationUrl       string   `json:",omitempty"`
+	RedirectUrl           string   `json:",omitempty"`
+	PosData               string   `json:",omitempty"`
+	TransactionSpeed      string   `json:",omitempty"`
+	FullNotifications     string   `json:",omitempty"`
+	ExtendedNotifications string   `json:",omitempty"`
+	Physical              string   `json:",omitempty"`
+	Buyer                 Buyer    `json:",omitempty"`
+	PaymentCurrencies     []string `json:",omitempty"`
+	JsonPayProRequired    string   `json:",omitempty"`
 }
 
 type Buyer struct {
-	Name       string
-	Address1   string
-	Address2   string
-	Locality   string
-	Region     string
-	PostalCode string
-	Country    string
-	Email      string
-	Phone      string
-	Notify     bool
+	Name       string `json:",omitempty"`
+	Address1   string `json:",omitempty"`
+	Address2   string `json:",omitempty"`
+	Locality   string `json:",omitempty"`
+	Region     string `json:",omitempty"`
+	PostalCode string `json:",omitempty"`
+	Country    string `json:",omitempty"`
+	Email      string `json:",omitempty"`
+	Phone      string `json:",omitempty"`
+	Notify     bool   `json:",omitempty"`
 }
 
 // Go struct mapping the JSON returned from the BitPay server when sending a POST or GET request to /invoices.

--- a/client/client.go
+++ b/client/client.go
@@ -34,119 +34,115 @@ type Token struct {
 }
 
 type Invoice struct {
-	Token                 string   `json:"token,omitempty"`
-	Price                 float64  `json:"price,omitempty"`
-	Currency              string   `json:"currency,omitempty"`
-	OrderId               string   `json:"order,omitempty"`
-	ItemDesc              string   `json:"itemDesc,omitempty"`
-	ItemCode              string   `json:"itemCode,omitempty"`
-	NotificationEmail     string   `json:"notificationEmail,omitempty"`
-	NotificationUrl       string   `json:"notificationUrl,omitempty"`
-	RedirectUrl           string   `json:"redirectUrl,omitempty"`
-	PosData               string   `json:"posData,omitempty"`
-	TransactionSpeed      string   `json:"transactionSpeed,omitempty"`
-	FullNotifications     string   `json:"fullNotifications,omitempty"`
-	ExtendedNotifications string   `json:"extendedNotifications,omitempty"`
-	Physical              string   `json:"physical,omitempty"`
-	Buyer                 *Buyer   `json:"buyer,omitempty"`
-	PaymentCurrencies     []string `json:"paymentCurrencies,omitempty"`
-	JsonPayProRequired    string   `json:",omitempty"`
-	//Additional Response Fiend
-	Url                            string                          `json:"url,omitempty"`
-	Status                         string                          `json:"status,omitempty"`
-	InvoiceTime                    *time.Time                      `json:",omitempty"`
-	ExpirationTime                 *time.Time                      `json:",omitempty"`
-	CurrentTime                    *time.Time                      `json:",omitempty"`
-	LowFeeDetected                 bool                            `json:",omitempty"`
-	AmountPaid                     float64                         `json:",omitempty"`
-	DisplayAmountPaid              float64                         `json:",omitempty"`
-	ExceptionStatus                bool                            `json:",omitempty"`
-	RefundAddressRequestPending    bool                            `json:",omitempty"`
-	BuyerProvidedInfo              *Buyer                          `json:",omitempty"`
-	PaymentSubtotals               *PaymentTotals                  `json:",omitempty"`
-	PaymentTotals                  *PaymentTotals                  `json:",omitempty"`
-	PaymentDisplayTotals           *PaymentDisplay                 `json:",omitempty"`
-	PaymentDisplaySubTotals        *PaymentDisplay                 `json:",omitempty"`
-	ExchangeRates                  *ExchangeRates                  `json:",omitempty"`
-	SupportedTransactionCurrencies *SupportedTransactionCurrencies `json:",omitempty"`
-	MinerFees                      *MinerFees                      `json:",omitempty"`
-	Addresses                      *PaymentDisplay                 `json:",omitempty"`
-	BitcoinAddress                 string                          `json:",omitempty"`
-	BtcDue                         string                          `json:"btcDue,omitempty"`
-	BtcPaid                        string                          `json:"btcPaid,omitempty"`
-	BtcPrice                       string                          `json:"btcPrice,omitempty"`
-	Id                             string                          `json:"id,omitempty"`
-}
-
-type Buyer struct {
-	Name       string `json:",omitempty"`
-	Address1   string `json:",omitempty"`
-	Address2   string `json:",omitempty"`
-	Locality   string `json:",omitempty"`
-	Region     string `json:",omitempty"`
-	PostalCode string `json:",omitempty"`
-	Country    string `json:",omitempty"`
-	Email      string `json:",omitempty"`
-	Phone      string `json:",omitempty"`
-	Notify     bool   `json:",omitempty"`
-}
-
-type PaymentTotals struct {
-	Btc             float64 `json:",omitempty"`
-	Bch             float64 `json:",omitempty"`
-	Eth             float64 `json:",omitempty"`
-	Gusd            float64 `json:",omitempty"`
-	Pax             float64 `json:",omitempty"`
-	Busd            float64 `json:",omitempty"`
-	Usdc            float64 `json:",omitempty"`
-	Xrp             float64 `json:",omitempty"`
-	Enabled         bool    `json:",omitempty"`
-	SatoshisPerByte float64 `json:",omitempty"`
-	TotalFee        float64 `json:",omitempty"`
-}
-
-type PaymentDisplay struct {
-	Btc  string `json:",omitempty"`
-	Bch  string `json:",omitempty"`
-	Eth  string `json:",omitempty"`
-	Gusd string `json:",omitempty"`
-	Pax  string `json:",omitempty"`
-	Busd string `json:",omitempty"`
-	Usdc string `json:",omitempty"`
-	Xrp  string `json:",omitempty"`
-}
-
-type ExchangeRates struct {
-	Btc  *PaymentTotals
-	Bch  *PaymentTotals
-	Eth  *PaymentTotals
-	Gusd *PaymentTotals
-	Pax  *PaymentTotals
-	Busd *PaymentTotals
-	Usdc *PaymentTotals
-	Xrp  *PaymentTotals
-}
-
-type SupportedTransactionCurrencies struct {
-	Btc  *PaymentTotals
-	Bch  *PaymentTotals
-	Eth  *PaymentTotals
-	Gusd *PaymentTotals
-	Pax  *PaymentTotals
-	Busd *PaymentTotals
-	Usdc *PaymentTotals
-	Xrp  *PaymentTotals
-}
-
-type MinerFees struct {
-	Btc  *PaymentTotals
-	Bch  *PaymentTotals
-	Eth  *PaymentTotals
-	Gusd *PaymentTotals
-	Pax  *PaymentTotals
-	Busd *PaymentTotals
-	Usdc *PaymentTotals
-	Xrp  *PaymentTotals
+	Addresses struct {
+		BTC string `json:"BTC"`
+	} `json:"addresses"`
+	AmountPaid     int    `json:"amountPaid"`
+	BitcoinAddress string `json:"bitcoinAddress"`
+	BtcDue         string `json:"btcDue"`
+	BtcPaid        string `json:"btcPaid"`
+	BtcPrice       string `json:"btcPrice"`
+	Buyer          struct {
+		Address1   interface{} `json:"address1"`
+		Address2   interface{} `json:"address2"`
+		Country    interface{} `json:"country"`
+		Email      interface{} `json:"email"`
+		Locality   interface{} `json:"locality"`
+		Name       interface{} `json:"name"`
+		Phone      interface{} `json:"phone"`
+		PostalCode interface{} `json:"postalCode"`
+		Region     interface{} `json:"region"`
+	} `json:"buyer"`
+	BuyerPaidBtcMinerFee interface{} `json:"buyerPaidBtcMinerFee"`
+	BuyerTotalBtcAmount  interface{} `json:"buyerTotalBtcAmount"`
+	CryptoInfo           []struct {
+		Address    string `json:"address"`
+		CryptoCode string `json:"cryptoCode"`
+		CryptoPaid string `json:"cryptoPaid"`
+		Due        string `json:"due"`
+		ExRates    struct {
+			USD int `json:"USD"`
+		} `json:"exRates"`
+		NetworkFee  string `json:"networkFee"`
+		Paid        string `json:"paid"`
+		PaymentType string `json:"paymentType"`
+		PaymentUrls struct {
+			BIP21  string      `json:"BIP21"`
+			BIP72  interface{} `json:"BIP72"`
+			BIP72B interface{} `json:"BIP72b"`
+			BIP73  interface{} `json:"BIP73"`
+			BOLT11 interface{} `json:"BOLT11"`
+		} `json:"paymentUrls"`
+		Payments []interface{} `json:"payments"`
+		Price    string        `json:"price"`
+		Rate     float64       `json:"rate"`
+		TotalDue string        `json:"totalDue"`
+		TxCount  int           `json:"txCount"`
+		URL      string        `json:"url"`
+	} `json:"cryptoInfo"`
+	Currency    string `json:"currency"`
+	CurrentTime int64  `json:"currentTime"`
+	ExRates     struct {
+		USD int `json:"USD"`
+	} `json:"exRates"`
+	ExceptionStatus bool `json:"exceptionStatus"`
+	ExchangeRates   struct {
+		BTC struct {
+			USD int `json:"USD"`
+		} `json:"BTC"`
+	} `json:"exchangeRates"`
+	ExpirationTime int64 `json:"expirationTime"`
+	Flags          struct {
+		Refundable bool `json:"refundable"`
+	} `json:"flags"`
+	GUID           string      `json:"guid"`
+	ID             string      `json:"id"`
+	InvoiceTime    int64       `json:"invoiceTime"`
+	ItemCode       interface{} `json:"itemCode"`
+	ItemDesc       interface{} `json:"itemDesc"`
+	LowFeeDetected bool        `json:"lowFeeDetected"`
+	MinerFees      struct {
+		BTC struct {
+			SatoshisPerByte int `json:"satoshisPerByte"`
+			TotalFee        int `json:"totalFee"`
+		} `json:"BTC"`
+	} `json:"minerFees"`
+	OrderID      interface{} `json:"orderId"`
+	PaymentCodes struct {
+		BTC struct {
+			BIP21  string      `json:"BIP21"`
+			BIP72  interface{} `json:"BIP72"`
+			BIP72B interface{} `json:"BIP72b"`
+			BIP73  interface{} `json:"BIP73"`
+			BOLT11 interface{} `json:"BOLT11"`
+		} `json:"BTC"`
+	} `json:"paymentCodes"`
+	PaymentSubtotals struct {
+		BTC int `json:"BTC"`
+	} `json:"paymentSubtotals"`
+	PaymentTotals struct {
+		BTC int `json:"BTC"`
+	} `json:"paymentTotals"`
+	PaymentUrls struct {
+		BIP21  string      `json:"BIP21"`
+		BIP72  interface{} `json:"BIP72"`
+		BIP72B interface{} `json:"BIP72b"`
+		BIP73  interface{} `json:"BIP73"`
+		BOLT11 interface{} `json:"BOLT11"`
+	} `json:"paymentUrls"`
+	PosData                        interface{} `json:"posData"`
+	Price                          int         `json:"price"`
+	Rate                           float64     `json:"rate"`
+	RefundAddressRequestPending    bool        `json:"refundAddressRequestPending"`
+	Status                         string      `json:"status"`
+	SupportedTransactionCurrencies struct {
+		BTC struct {
+			Enabled bool        `json:"enabled"`
+			Reason  interface{} `json:"reason"`
+		} `json:"BTC"`
+	} `json:"supportedTransactionCurrencies"`
+	Token string `json:"token"`
+	URL   string `json:"url"`
 }
 
 // Go struct mapping the JSON returned from the BitPay server when sending a POST or GET request to /invoices.

--- a/client/client.go
+++ b/client/client.go
@@ -388,7 +388,12 @@ func setHttpClient(client *Client) *http.Client {
 
 func processErrorMessage(response *http.Response, jsonContents map[string]interface{}) error {
 	responseStatus := strconv.Itoa(response.StatusCode)
-	contentError := responseStatus + ": " + jsonContents["error"].(string)
+	var contentError string
+	if jsonContents != nil {
+		contentError = responseStatus + ": " + jsonContents["error"].(string)
+	} else {
+		contentError = responseStatus
+	}
 	return errors.New(contentError)
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -144,7 +144,14 @@ func (client *Client) Post(path string, paylo map[string]string) (response *http
 func (client *Client) GetInvoice(invId string) (inv invoice, err error) {
 	url := client.ApiUri + "/invoices/" + invId
 	htclient := setHttpClient(client)
-	response, _ := htclient.Get(url)
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Add("content-type", "application/json")
+	req.Header.Add("X-accept-version", "2.0.0")
+	publ := ku.ExtractCompressedPublicKey(client.Pem)
+	req.Header.Add("X-Identity", publ)
+	sig := ku.Sign(url, client.Pem)
+	req.Header.Add("X-Signature", sig)
+	response, _ := htclient.Do(req)
 	inv, err = processInvoice(response)
 	return inv, err
 }

--- a/client/client.go
+++ b/client/client.go
@@ -34,30 +34,29 @@ type Token struct {
 }
 
 type Invoice struct {
-	Token                 string   `json:",omitempty"`
-	Price                 float64  `json:",omitempty"`
-	Currency              string   `json:",omitempty"`
-	OrderId               string   `json:",omitempty"`
-	ItemDesc              string   `json:",omitempty"`
-	ItemCode              string   `json:",omitempty"`
-	NotificationEmail     string   `json:",omitempty"`
-	NotificationUrl       string   `json:",omitempty"`
-	RedirectUrl           string   `json:",omitempty"`
-	PosData               string   `json:",omitempty"`
-	TransactionSpeed      string   `json:",omitempty"`
-	FullNotifications     string   `json:",omitempty"`
-	ExtendedNotifications string   `json:",omitempty"`
-	Physical              string   `json:",omitempty"`
-	Buyer                 *Buyer   `json:",omitempty"`
-	PaymentCurrencies     []string `json:",omitempty"`
+	Token                 string   `json:"token,omitempty"`
+	Price                 float64  `json:"price,omitempty"`
+	Currency              string   `json:"currency,omitempty"`
+	OrderId               string   `json:"order,omitempty"`
+	ItemDesc              string   `json:"itemDesc,omitempty"`
+	ItemCode              string   `json:"itemCode,omitempty"`
+	NotificationEmail     string   `json:"notificationEmail,omitempty"`
+	NotificationUrl       string   `json:"notificationUrl,omitempty"`
+	RedirectUrl           string   `json:"redirectUrl,omitempty"`
+	PosData               string   `json:"posData,omitempty"`
+	TransactionSpeed      string   `json:"transactionSpeed,omitempty"`
+	FullNotifications     string   `json:"fullNotifications,omitempty"`
+	ExtendedNotifications string   `json:"extendedNotifications,omitempty"`
+	Physical              string   `json:"physical,omitempty"`
+	Buyer                 *Buyer   `json:"buyer,omitempty"`
+	PaymentCurrencies     []string `json:"paymentCurrencies,omitempty"`
 	JsonPayProRequired    string   `json:",omitempty"`
 	//Additional Response Fiend
-	Url                            string                          `json:",omitempty"`
-	Status                         string                          `json:",omitempty"`
+	Url                            string                          `json:"url,omitempty"`
+	Status                         string                          `json:"status,omitempty"`
 	InvoiceTime                    *time.Time                      `json:",omitempty"`
 	ExpirationTime                 *time.Time                      `json:",omitempty"`
 	CurrentTime                    *time.Time                      `json:",omitempty"`
-	Id                             string                          `json:",omitempty"`
 	LowFeeDetected                 bool                            `json:",omitempty"`
 	AmountPaid                     float64                         `json:",omitempty"`
 	DisplayAmountPaid              float64                         `json:",omitempty"`
@@ -73,9 +72,10 @@ type Invoice struct {
 	MinerFees                      *MinerFees                      `json:",omitempty"`
 	Addresses                      *PaymentDisplay                 `json:",omitempty"`
 	BitcoinAddress                 string                          `json:",omitempty"`
-	BtcDue                         string                          `json:",omitempty"`
-	BtcPaid                        string                          `json:",omitempty"`
-	BtcPrice                       string                          `json:",omitempty"`
+	BtcDue                         string                          `json:"btcDue,omitempty"`
+	BtcPaid                        string                          `json:"btcPaid,omitempty"`
+	BtcPrice                       string                          `json:"btcPrice,omitempty"`
+	Id                             string                          `json:"id,omitempty"`
 }
 
 type Buyer struct {

--- a/client/client.go
+++ b/client/client.go
@@ -71,6 +71,11 @@ type Invoice struct {
 	ExchangeRates                  *ExchangeRates                  `json:",omitempty"`
 	SupportedTransactionCurrencies *SupportedTransactionCurrencies `json:",omitempty"`
 	MinerFees                      *MinerFees                      `json:",omitempty"`
+	Addresses                      *PaymentDisplay                 `json:",omitempty"`
+	BitcoinAddress                 string                          `json:",omitempty"`
+	BtcDue                         string                          `json:",omitempty"`
+	BtcPaid                        string                          `json:",omitempty"`
+	BtcPrice                       string                          `json:",omitempty"`
 }
 
 type Buyer struct {

--- a/client/client.go
+++ b/client/client.go
@@ -346,7 +346,10 @@ func (client *Client) GetTokens() (tokes []map[string]string, err error) {
 	req.Header.Add("X-Identity", publ)
 	sig := ku.Sign(url, client.Pem)
 	req.Header.Add("X-Signature", sig)
-	response, _ := htclient.Do(req)
+	response, err := htclient.Do(req)
+	if err != nil {
+		return tokes, err
+	}
 	defer response.Body.Close()
 	contents, err := ioutil.ReadAll(response.Body)
 	if err != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -48,29 +48,29 @@ type Invoice struct {
 	FullNotifications     string   `json:",omitempty"`
 	ExtendedNotifications string   `json:",omitempty"`
 	Physical              string   `json:",omitempty"`
-	Buyer                 Buyer    `json:",omitempty"`
+	Buyer                 *Buyer   `json:",omitempty"`
 	PaymentCurrencies     []string `json:",omitempty"`
 	JsonPayProRequired    string   `json:",omitempty"`
 	//Additional Response Fiend
-	Url                            string                         `json:",omitempty"`
-	Status                         string                         `json:",omitempty"`
-	InvoiceTime                    time.Time                      `json:",omitempty"`
-	ExpirationTime                 time.Time                      `json:",omitempty"`
-	CurrentTime                    time.Time                      `json:",omitempty"`
-	Id                             string                         `json:",omitempty"`
-	LowFeeDetected                 bool                           `json:",omitempty"`
-	AmountPaid                     float64                        `json:",omitempty"`
-	DisplayAmountPaid              float64                        `json:",omitempty"`
-	ExceptionStatus                bool                           `json:",omitempty"`
-	RefundAddressRequestPending    bool                           `json:",omitempty"`
-	BuyerProvidedInfo              Buyer                          `json:",omitempty"`
-	PaymentSubtotals               PaymentTotals                  `json:",omitempty"`
-	PaymentTotals                  PaymentTotals                  `json:",omitempty"`
-	PaymentDisplayTotals           PaymentDisplay                 `json:",omitempty"`
-	PaymentDisplaySubTotals        PaymentDisplay                 `json:",omitempty"`
-	ExchangeRates                  ExchangeRates                  `json:",omitempty"`
-	SupportedTransactionCurrencies SupportedTransactionCurrencies `json:",omitempty"`
-	MinerFees                      MinerFees                      `json:",omitempty"`
+	Url                            string                          `json:",omitempty"`
+	Status                         string                          `json:",omitempty"`
+	InvoiceTime                    *time.Time                      `json:",omitempty"`
+	ExpirationTime                 *time.Time                      `json:",omitempty"`
+	CurrentTime                    *time.Time                      `json:",omitempty"`
+	Id                             string                          `json:",omitempty"`
+	LowFeeDetected                 bool                            `json:",omitempty"`
+	AmountPaid                     float64                         `json:",omitempty"`
+	DisplayAmountPaid              float64                         `json:",omitempty"`
+	ExceptionStatus                bool                            `json:",omitempty"`
+	RefundAddressRequestPending    bool                            `json:",omitempty"`
+	BuyerProvidedInfo              *Buyer                          `json:",omitempty"`
+	PaymentSubtotals               *PaymentTotals                  `json:",omitempty"`
+	PaymentTotals                  *PaymentTotals                  `json:",omitempty"`
+	PaymentDisplayTotals           *PaymentDisplay                 `json:",omitempty"`
+	PaymentDisplaySubTotals        *PaymentDisplay                 `json:",omitempty"`
+	ExchangeRates                  *ExchangeRates                  `json:",omitempty"`
+	SupportedTransactionCurrencies *SupportedTransactionCurrencies `json:",omitempty"`
+	MinerFees                      *MinerFees                      `json:",omitempty"`
 }
 
 type Buyer struct {
@@ -112,36 +112,36 @@ type PaymentDisplay struct {
 }
 
 type ExchangeRates struct {
-	Btc  PaymentTotals
-	Bch  PaymentTotals
-	Eth  PaymentTotals
-	Gusd PaymentTotals
-	Pax  PaymentTotals
-	Busd PaymentTotals
-	Usdc PaymentTotals
-	Xrp  PaymentTotals
+	Btc  *PaymentTotals
+	Bch  *PaymentTotals
+	Eth  *PaymentTotals
+	Gusd *PaymentTotals
+	Pax  *PaymentTotals
+	Busd *PaymentTotals
+	Usdc *PaymentTotals
+	Xrp  *PaymentTotals
 }
 
 type SupportedTransactionCurrencies struct {
-	Btc  PaymentTotals
-	Bch  PaymentTotals
-	Eth  PaymentTotals
-	Gusd PaymentTotals
-	Pax  PaymentTotals
-	Busd PaymentTotals
-	Usdc PaymentTotals
-	Xrp  PaymentTotals
+	Btc  *PaymentTotals
+	Bch  *PaymentTotals
+	Eth  *PaymentTotals
+	Gusd *PaymentTotals
+	Pax  *PaymentTotals
+	Busd *PaymentTotals
+	Usdc *PaymentTotals
+	Xrp  *PaymentTotals
 }
 
 type MinerFees struct {
-	Btc  PaymentTotals
-	Bch  PaymentTotals
-	Eth  PaymentTotals
-	Gusd PaymentTotals
-	Pax  PaymentTotals
-	Busd PaymentTotals
-	Usdc PaymentTotals
-	Xrp  PaymentTotals
+	Btc  *PaymentTotals
+	Bch  *PaymentTotals
+	Eth  *PaymentTotals
+	Gusd *PaymentTotals
+	Pax  *PaymentTotals
+	Busd *PaymentTotals
+	Usdc *PaymentTotals
+	Xrp  *PaymentTotals
 }
 
 // Go struct mapping the JSON returned from the BitPay server when sending a POST or GET request to /invoices.
@@ -296,7 +296,7 @@ func (client *Client) Post(path string, paylo interface{}) (response *http.Respo
 }
 
 // GetInvoice is a public facade method, any client which has the ApiUri field set can retrieve an invoice from that endpoint, provided they have the invoice id.
-func (client *Client) GetInvoice(invId string) (inv invoice, err error) {
+func (client *Client) GetInvoice(invId string) (inv Invoice, err error) {
 	url := client.ApiUri + "/invoices/" + invId
 	htclient := setHttpClient(client)
 	req, _ := http.NewRequest("GET", url, nil)
@@ -375,7 +375,7 @@ func processToken(response *http.Response, jsonContents map[string]interface{}) 
 	return tok, nil
 }
 
-func processInvoice(response *http.Response) (inv invoice, err error) {
+func processInvoice(response *http.Response) (inv Invoice, err error) {
 	defer response.Body.Close()
 	contents, _ := ioutil.ReadAll(response.Body)
 	var jsonContents map[string]interface{}

--- a/client/client.go
+++ b/client/client.go
@@ -34,115 +34,139 @@ type Token struct {
 }
 
 type Invoice struct {
-	Addresses struct {
-		BTC string `json:"BTC"`
-	} `json:"addresses"`
-	AmountPaid     int    `json:"amountPaid"`
-	BitcoinAddress string `json:"bitcoinAddress"`
-	BtcDue         string `json:"btcDue"`
-	BtcPaid        string `json:"btcPaid"`
-	BtcPrice       string `json:"btcPrice"`
-	Buyer          struct {
-		Address1   interface{} `json:"address1"`
-		Address2   interface{} `json:"address2"`
-		Country    interface{} `json:"country"`
-		Email      interface{} `json:"email"`
-		Locality   interface{} `json:"locality"`
-		Name       interface{} `json:"name"`
-		Phone      interface{} `json:"phone"`
-		PostalCode interface{} `json:"postalCode"`
-		Region     interface{} `json:"region"`
-	} `json:"buyer"`
-	BuyerPaidBtcMinerFee interface{} `json:"buyerPaidBtcMinerFee"`
-	BuyerTotalBtcAmount  interface{} `json:"buyerTotalBtcAmount"`
+	Addresses            *PaymentDisplay `json:"addresses,omitempty"`
+	AmountPaid           int             `json:"amountPaid,omitempty"`
+	BitcoinAddress       string          `json:"bitcoinAddress,omitempty"`
+	BtcDue               string          `json:"btcDue,omitempty"`
+	BtcPaid              string          `json:"btcPaid,omitempty"`
+	BtcPrice             string          `json:"btcPrice,omitempty"`
+	Buyer                *Buyer          `json:"buyer,omitempty"`
+	BuyerPaidBtcMinerFee interface{}     `json:"buyerPaidBtcMinerFee,omitempty"`
+	BuyerTotalBtcAmount  interface{}     `json:"buyerTotalBtcAmount,omitempty"`
 	CryptoInfo           []struct {
-		Address    string `json:"address"`
-		CryptoCode string `json:"cryptoCode"`
-		CryptoPaid string `json:"cryptoPaid"`
-		Due        string `json:"due"`
+		Address    string `json:"address,omitempty"`
+		CryptoCode string `json:"cryptoCode,omitempty"`
+		CryptoPaid string `json:"cryptoPaid,omitempty"`
+		Due        string `json:"due,omitempty"`
 		ExRates    struct {
-			USD int `json:"USD"`
-		} `json:"exRates"`
-		NetworkFee  string `json:"networkFee"`
-		Paid        string `json:"paid"`
-		PaymentType string `json:"paymentType"`
+			USD int `json:"USD,omitempty"`
+		} `json:"exRates,omitempty"`
+		NetworkFee  string `json:"networkFee,omitempty"`
+		Paid        string `json:"paid,omitempty"`
+		PaymentType string `json:"paymentType,omitempty"`
 		PaymentUrls struct {
-			BIP21  string      `json:"BIP21"`
-			BIP72  interface{} `json:"BIP72"`
-			BIP72B interface{} `json:"BIP72b"`
-			BIP73  interface{} `json:"BIP73"`
-			BOLT11 interface{} `json:"BOLT11"`
-		} `json:"paymentUrls"`
-		Payments []interface{} `json:"payments"`
-		Price    string        `json:"price"`
-		Rate     float64       `json:"rate"`
-		TotalDue string        `json:"totalDue"`
-		TxCount  int           `json:"txCount"`
-		URL      string        `json:"url"`
-	} `json:"cryptoInfo"`
-	Currency    string `json:"currency"`
-	CurrentTime int64  `json:"currentTime"`
-	ExRates     struct {
-		USD int `json:"USD"`
-	} `json:"exRates"`
-	ExceptionStatus bool `json:"exceptionStatus"`
-	ExchangeRates   struct {
+			BIP21  string      `json:"BIP21,omitempty"`
+			BIP72  interface{} `json:"BIP72,omitempty"`
+			BIP72B interface{} `json:"BIP72b,omitempty"`
+			BIP73  interface{} `json:"BIP73,omitempty"`
+			BOLT11 interface{} `json:"BOLT11,omitempty"`
+		} `json:"paymentUrls,omitempty"`
+		Payments []interface{} `json:"payments,omitempty"`
+		Price    string        `json:"price,omitempty"`
+		Rate     float64       `json:"rate,omitempty"`
+		TotalDue string        `json:"totalDue,omitempty"`
+		TxCount  int           `json:"txCount,omitempty"`
+		URL      string        `json:"url,omitempty"`
+	} `json:"cryptoInfo,omitempty"`
+	Currency    string `json:"currency,omitempty"`
+	CurrentTime int64  `json:"currentTime,omitempty"`
+	/*
+		ExRates     struct {
+			USD int `json:"USD,omitempty"`
+		} `json:"exRates,omitempty"`
+	*/
+
+	ExceptionStatus bool `json:"exceptionStatus,omitempty"`
+	/*
+		ExchangeRates   struct {
+			BTC struct {
+				USD int `json:"USD,omitempty"`
+			} `json:"BTC,omitempty"`
+		} `json:"exchangeRates,omitempty"`
+	*/
+
+	ExpirationTime int64 `json:"expirationTime,omitempty"`
+	/*
+		Flags          struct {
+			Refundable bool `json:"refundable,omitempty"`
+		} `json:"flags,omitempty"`
+	*/
+	GUID           string      `json:"guid,omitempty"`
+	ID             string      `json:"id,omitempty"`
+	InvoiceTime    int64       `json:"invoiceTime,omitempty"`
+	ItemCode       interface{} `json:"itemCode,omitempty"`
+	ItemDesc       interface{} `json:"itemDesc,omitempty"`
+	LowFeeDetected bool        `json:"lowFeeDetected,omitempty"`
+	/*MinerFees      struct {
 		BTC struct {
-			USD int `json:"USD"`
-		} `json:"BTC"`
-	} `json:"exchangeRates"`
-	ExpirationTime int64 `json:"expirationTime"`
-	Flags          struct {
-		Refundable bool `json:"refundable"`
-	} `json:"flags"`
-	GUID           string      `json:"guid"`
-	ID             string      `json:"id"`
-	InvoiceTime    int64       `json:"invoiceTime"`
-	ItemCode       interface{} `json:"itemCode"`
-	ItemDesc       interface{} `json:"itemDesc"`
-	LowFeeDetected bool        `json:"lowFeeDetected"`
-	MinerFees      struct {
+			SatoshisPerByte int `json:"satoshisPerByte,omitempty"`
+			TotalFee        int `json:"totalFee,omitempty"`
+		} `json:"BTC,omitempty"`
+	} `json:"minerFees,omitempty"`
+	*/
+	OrderID interface{} `json:"orderId,omitempty"`
+	/*PaymentCodes struct {
 		BTC struct {
-			SatoshisPerByte int `json:"satoshisPerByte"`
-			TotalFee        int `json:"totalFee"`
-		} `json:"BTC"`
-	} `json:"minerFees"`
-	OrderID      interface{} `json:"orderId"`
-	PaymentCodes struct {
-		BTC struct {
-			BIP21  string      `json:"BIP21"`
-			BIP72  interface{} `json:"BIP72"`
-			BIP72B interface{} `json:"BIP72b"`
-			BIP73  interface{} `json:"BIP73"`
-			BOLT11 interface{} `json:"BOLT11"`
-		} `json:"BTC"`
-	} `json:"paymentCodes"`
-	PaymentSubtotals struct {
-		BTC int `json:"BTC"`
-	} `json:"paymentSubtotals"`
+			BIP21  string      `json:"BIP21,omitempty"`
+			BIP72  interface{} `json:"BIP72,omitempty"`
+			BIP72B interface{} `json:"BIP72b,omitempty"`
+			BIP73  interface{} `json:"BIP73,omitempty"`
+			BOLT11 interface{} `json:"BOLT11,omitempty"`
+		} `json:"BTC,omitempty"`
+	} `json:"paymentCodes,omitempty"`
+	*/
+	/*PaymentSubtotals struct {
+		BTC int `json:"BTC,omitempty"`
+	} `json:"paymentSubtotals,omitempty"`
 	PaymentTotals struct {
-		BTC int `json:"BTC"`
-	} `json:"paymentTotals"`
+		BTC int `json:"BTC,omitempty"`
+	} `json:"paymentTotals,omitempty"`
 	PaymentUrls struct {
-		BIP21  string      `json:"BIP21"`
-		BIP72  interface{} `json:"BIP72"`
-		BIP72B interface{} `json:"BIP72b"`
-		BIP73  interface{} `json:"BIP73"`
-		BOLT11 interface{} `json:"BOLT11"`
-	} `json:"paymentUrls"`
-	PosData                        interface{} `json:"posData"`
-	Price                          int         `json:"price"`
-	Rate                           float64     `json:"rate"`
-	RefundAddressRequestPending    bool        `json:"refundAddressRequestPending"`
-	Status                         string      `json:"status"`
-	SupportedTransactionCurrencies struct {
+		BIP21  string      `json:"BIP21,omitempty"`
+		BIP72  interface{} `json:"BIP72,omitempty"`
+		BIP72B interface{} `json:"BIP72b,omitempty"`
+		BIP73  interface{} `json:"BIP73,omitempty"`
+		BOLT11 interface{} `json:"BOLT11,omitempty"`
+	} `json:"paymentUrls,omitempty"`
+	*/
+	PosData                     interface{} `json:"posData,omitempty"`
+	Price                       float64     `json:"price,omitempty"`
+	Rate                        float64     `json:"rate,omitempty"`
+	RefundAddressRequestPending bool        `json:"refundAddressRequestPending,omitempty"`
+	Status                      string      `json:"status,omitempty"`
+	/*SupportedTransactionCurrencies struct {
 		BTC struct {
 			Enabled bool        `json:"enabled"`
 			Reason  interface{} `json:"reason"`
 		} `json:"BTC"`
-	} `json:"supportedTransactionCurrencies"`
-	Token string `json:"token"`
-	URL   string `json:"url"`
+	} `json:"supportedTransactionCurrencies,omitempty"`
+	*/
+	PaymentCurrencies []string `json:"paymentCurrencies,omitempty"`
+	Token             string   `json:"token,omitempty"`
+	URL               string   `json:"url,omitempty"`
+}
+
+type PaymentDisplay struct {
+	Btc  string `json:"BTC,omitempty"`
+	Bch  string `json:"BCH,omitempty"`
+	Eth  string `json:"ETH,omitempty"`
+	Gusd string `json:"GUSD,omitempty"`
+	Pax  string `json:"PAX,omitempty"`
+	Busd string `json:"BUSD,omitempty"`
+	Usdc string `json:"USDC,omitempty"`
+	Xrp  string `json:"XRP,omitempty"`
+}
+
+type Buyer struct {
+	Address1   interface{} `json:"address1,omitempty"`
+	Address2   interface{} `json:"address2,omitempty"`
+	Country    interface{} `json:"country,omitempty"`
+	Email      interface{} `json:"email,omitempty"`
+	Locality   interface{} `json:"locality,omitempty"`
+	Name       interface{} `json:"name,omitempty"`
+	Phone      interface{} `json:"phone,omitempty"`
+	PostalCode interface{} `json:"postalCode,omitempty"`
+	Region     interface{} `json:"region,omitempty"`
 }
 
 // Go struct mapping the JSON returned from the BitPay server when sending a POST or GET request to /invoices.
@@ -228,9 +252,8 @@ func (client *Client) CreateInvoice(i Invoice) (inv Invoice, err error) {
 
 	i.Token = client.Token.Token
 	response, _ := client.Post("invoices", i)
-	body, err := ioutil.ReadAll(response.Body)
 	var invoice Invoice
-	json.Unmarshal(body, &invoice)
+	invoice, err = processInvoice(response)
 	return invoice, err
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -34,9 +34,9 @@ type Token struct {
 }
 
 type Invoice struct {
-	Token                 string
-	Price                 float64
-	Currency              string
+	Token                 string   `json:",omitempty"`
+	Price                 float64  `json:",omitempty"`
+	Currency              string   `json:",omitempty"`
 	OrderId               string   `json:",omitempty"`
 	ItemDesc              string   `json:",omitempty"`
 	ItemCode              string   `json:",omitempty"`
@@ -51,6 +51,26 @@ type Invoice struct {
 	Buyer                 Buyer    `json:",omitempty"`
 	PaymentCurrencies     []string `json:",omitempty"`
 	JsonPayProRequired    string   `json:",omitempty"`
+	//Additional Response Fiend
+	Url                            string                         `json:",omitempty"`
+	Status                         string                         `json:",omitempty"`
+	InvoiceTime                    time.Time                      `json:",omitempty"`
+	ExpirationTime                 time.Time                      `json:",omitempty"`
+	CurrentTime                    time.Time                      `json:",omitempty"`
+	Id                             string                         `json:",omitempty"`
+	LowFeeDetected                 bool                           `json:",omitempty"`
+	AmountPaid                     float64                        `json:",omitempty"`
+	DisplayAmountPaid              float64                        `json:",omitempty"`
+	ExceptionStatus                bool                           `json:",omitempty"`
+	RefundAddressRequestPending    bool                           `json:",omitempty"`
+	BuyerProvidedInfo              Buyer                          `json:",omitempty"`
+	PaymentSubtotals               PaymentTotals                  `json:",omitempty"`
+	PaymentTotals                  PaymentTotals                  `json:",omitempty"`
+	PaymentDisplayTotals           PaymentDisplay                 `json:",omitempty"`
+	PaymentDisplaySubTotals        PaymentDisplay                 `json:",omitempty"`
+	ExchangeRates                  ExchangeRates                  `json:",omitempty"`
+	SupportedTransactionCurrencies SupportedTransactionCurrencies `json:",omitempty"`
+	MinerFees                      MinerFees                      `json:",omitempty"`
 }
 
 type Buyer struct {
@@ -64,6 +84,64 @@ type Buyer struct {
 	Email      string `json:",omitempty"`
 	Phone      string `json:",omitempty"`
 	Notify     bool   `json:",omitempty"`
+}
+
+type PaymentTotals struct {
+	Btc             float64 `json:",omitempty"`
+	Bch             float64 `json:",omitempty"`
+	Eth             float64 `json:",omitempty"`
+	Gusd            float64 `json:",omitempty"`
+	Pax             float64 `json:",omitempty"`
+	Busd            float64 `json:",omitempty"`
+	Usdc            float64 `json:",omitempty"`
+	Xrp             float64 `json:",omitempty"`
+	Enabled         bool    `json:",omitempty"`
+	SatoshisPerByte float64 `json:",omitempty"`
+	TotalFee        float64 `json:",omitempty"`
+}
+
+type PaymentDisplay struct {
+	Btc  string `json:",omitempty"`
+	Bch  string `json:",omitempty"`
+	Eth  string `json:",omitempty"`
+	Gusd string `json:",omitempty"`
+	Pax  string `json:",omitempty"`
+	Busd string `json:",omitempty"`
+	Usdc string `json:",omitempty"`
+	Xrp  string `json:",omitempty"`
+}
+
+type ExchangeRates struct {
+	Btc  PaymentTotals
+	Bch  PaymentTotals
+	Eth  PaymentTotals
+	Gusd PaymentTotals
+	Pax  PaymentTotals
+	Busd PaymentTotals
+	Usdc PaymentTotals
+	Xrp  PaymentTotals
+}
+
+type SupportedTransactionCurrencies struct {
+	Btc  PaymentTotals
+	Bch  PaymentTotals
+	Eth  PaymentTotals
+	Gusd PaymentTotals
+	Pax  PaymentTotals
+	Busd PaymentTotals
+	Usdc PaymentTotals
+	Xrp  PaymentTotals
+}
+
+type MinerFees struct {
+	Btc  PaymentTotals
+	Bch  PaymentTotals
+	Eth  PaymentTotals
+	Gusd PaymentTotals
+	Pax  PaymentTotals
+	Busd PaymentTotals
+	Usdc PaymentTotals
+	Xrp  PaymentTotals
 }
 
 // Go struct mapping the JSON returned from the BitPay server when sending a POST or GET request to /invoices.
@@ -140,7 +218,7 @@ type Address struct {
 }
 
 // CreateInvoice returns an invoice type or pass the error from the server. The method will create an invoice on the BitPay server.
-func (client *Client) CreateInvoice(i Invoice) (inv invoice, err error) {
+func (client *Client) CreateInvoice(i Invoice) (inv Invoice, err error) {
 	match, _ := regexp.MatchString("^[[:upper:]]{3}$", i.Currency)
 	if !match {
 		err = errors.New("BitPayArgumentError: invalid currency code")
@@ -150,7 +228,7 @@ func (client *Client) CreateInvoice(i Invoice) (inv invoice, err error) {
 	i.Token = client.Token.Token
 	response, _ := client.Post("invoices", i)
 	body, err := ioutil.ReadAll(response.Body)
-	var invoice invoice
+	var invoice Invoice
 	json.Unmarshal(body, &invoice)
 	return invoice, err
 }

--- a/client/client.go
+++ b/client/client.go
@@ -330,7 +330,10 @@ func (client *Client) GetInvoice(invId string) (inv Invoice, err error) {
 	req.Header.Add("X-Identity", publ)
 	sig := ku.Sign(url, client.Pem)
 	req.Header.Add("X-Signature", sig)
-	response, _ := htclient.Do(req)
+	response, err := htclient.Do(req)
+	if err != nil {
+		return inv, err
+	}
 	inv, err = processInvoice(response)
 	return inv, err
 }

--- a/client/client.go
+++ b/client/client.go
@@ -348,7 +348,10 @@ func (client *Client) GetTokens() (tokes []map[string]string, err error) {
 	req.Header.Add("X-Signature", sig)
 	response, _ := htclient.Do(req)
 	defer response.Body.Close()
-	contents, _ := ioutil.ReadAll(response.Body)
+	contents, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return tokes, err
+	}
 	var jsonContents map[string]interface{}
 	json.Unmarshal(contents, &jsonContents)
 	if response.StatusCode/100 != 2 {


### PR DESCRIPTION
According to documentation for [GetInvoice](https://bitpay.com/api/#rest-api-resources-invoices-create-an-invoice), `x-accept-version`, `content-type` headers are required.
Moreover, adding `x-identity` and `x-signature` header would allow merchant facade tokens to work.